### PR TITLE
Add More Context To Error Tracking

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,3 +37,12 @@ jobs:
         NODE_ENV: production
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+    - name: Create Sentry release
+      uses: getsentry/action-release@v1
+      env:
+        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+        SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+      with:
+        environment: production

--- a/src/App/Services/ErrorTracker/Domain/ErrorTracker/index.ts
+++ b/src/App/Services/ErrorTracker/Domain/ErrorTracker/index.ts
@@ -2,6 +2,8 @@ type ErrorTracker = {
     handler: (handler: Function) => Function;
 
     captureException: (err: Error) => Promise<void>
+
+    setContext: (key: string, value: any) => Promise<void>
 }
 
 export default ErrorTracker;

--- a/src/App/Services/ErrorTracker/Framework/ServiceProvider/index.ts
+++ b/src/App/Services/ErrorTracker/Framework/ServiceProvider/index.ts
@@ -1,6 +1,7 @@
 import { bind, resolve } from '../../../../Container';
 import config from '../../../../Config';
 import Sentry from '../../Infrastructure/Sentry';
+import InMemory from '../../Infrastructure/InMemory';
 import ErrorTracker from '../../Domain/ErrorTracker';
 import { Environment } from '../../../../../Bot/Shared/Domain/Environment';
 
@@ -8,27 +9,7 @@ const ServiceProvider = () => {
     bind('ErrorTracker', (): ErrorTracker => {
         
         if (config('app.env') as Environment === 'local') {
-            return {
-                handler: (fn: Function) => {
-                    return (...args: any) => {
-                        return fn(...args)
-                            .catch((err: Error) => {
-                                console.log('ErrorTracker handled: ', err);
-                                throw err;
-                            });
-                    };
-                },
-
-                captureException: (err: Error) => {
-                    console.log('ErrorTracker captured: ', err);
-                    return Promise.resolve();
-                },
-
-                setContext: (key: string, value: any) => {
-                    console.log('Setting ErrorTracker context', key, value);
-                    return Promise.resolve();
-                }
-            } as ErrorTracker;
+            return InMemory();
         }
 
         return Sentry(config('sentry.dsn'), config('app.env')); 

--- a/src/App/Services/ErrorTracker/Framework/ServiceProvider/index.ts
+++ b/src/App/Services/ErrorTracker/Framework/ServiceProvider/index.ts
@@ -22,6 +22,11 @@ const ServiceProvider = () => {
                 captureException: (err: Error) => {
                     console.log('ErrorTracker captured: ', err);
                     return Promise.resolve();
+                },
+
+                setContext: (key: string, value: any) => {
+                    console.log('Setting ErrorTracker context', key, value);
+                    return Promise.resolve();
                 }
             } as ErrorTracker;
         }

--- a/src/App/Services/ErrorTracker/Infrastructure/InMemory/index.ts
+++ b/src/App/Services/ErrorTracker/Infrastructure/InMemory/index.ts
@@ -1,0 +1,25 @@
+import ErrorTracker from '../../Domain/ErrorTracker';
+
+export default (): ErrorTracker => {
+    return {
+        handler: (fn: Function) => {
+            return (...args: any) => {
+                return fn(...args)
+                    .catch((err: Error) => {
+                        console.log('ErrorTracker handled: ', err);
+                        throw err;
+                    });
+            };
+        },
+
+        captureException: (err: Error) => {
+            console.log('ErrorTracker captured: ', err);
+            return Promise.resolve();
+        },
+
+        setContext: (key: string, value: any) => {
+            console.log('Setting ErrorTracker context', key, value);
+            return Promise.resolve();
+        }
+    };
+};

--- a/src/App/Services/ErrorTracker/Infrastructure/Sentry/index.test.ts
+++ b/src/App/Services/ErrorTracker/Infrastructure/Sentry/index.test.ts
@@ -5,6 +5,7 @@ jest.mock('@sentry/serverless', () => {
             wrapHandler: jest.fn(),
         },
         captureException: jest.fn(),
+        setContext: jest.fn(),
     }
 })
 
@@ -52,4 +53,19 @@ describe('Sentry', () => {
 
         expect(SentryIO.captureException).toHaveBeenCalledWith(error);
     });
+
+    it ('should set additional context', () => {
+        const ErrorTracker = Sentry('mock_dsn', 'stage');
+        const post = {
+            id: 'ea59d635-356e-48fd-afbf-3c337dd30e5b',
+            content: `If you're nothing without the suit, then you shouldn't have it.`,
+            images: [],
+            type: 'twitter',
+            crossPostId: 'ea59d635-356e-48fd-afbf-3c337dd30e5b',
+        };
+        
+        ErrorTracker.setContext('post', post);
+
+        expect(SentryIO.setContext).toHaveBeenCalledWith('post', post);
+    })
 });

--- a/src/App/Services/ErrorTracker/Infrastructure/Sentry/index.ts
+++ b/src/App/Services/ErrorTracker/Infrastructure/Sentry/index.ts
@@ -17,6 +17,11 @@ const Sentry = (dsn: string, environment: Environment): ErrorTracker => {
         captureException: (err: Error): Promise<void> => {
             SentryIO.captureException(err);
             return Promise.resolve();
+        },
+
+        setContext: (key: string, value: any): Promise<void> => {
+            SentryIO.setContext(key, value);
+            return Promise.resolve();
         }
     };
 }

--- a/src/Bot/Posts/Application/Commands/PublishNextToAllNetworks/index.test.ts
+++ b/src/Bot/Posts/Application/Commands/PublishNextToAllNetworks/index.test.ts
@@ -1,4 +1,5 @@
 import InMemoryRepository from '../../../Infrastructure/InMemoryRepository';
+import InMemoryErrorTracker from '../../../../../App/Services/ErrorTracker/Infrastructure/InMemory';
 import PublishNextToAllNetworks from './';
 import { Post, MakePostFromObject, PostPrimitiveObject } from '../../../Domain/Post';
 import { SocialNetwork } from '../../../Domain/SocialNetwork';
@@ -35,9 +36,10 @@ describe('PublishNextToAllNetworks', () => {
     it ('should publish all cross posts and remove them from the repository', () => {
         const repository = InMemoryRepository();
         const network = makeMockNetwork();
+        const errorTracker = InMemoryErrorTracker();
 
         return saturateRepository(repository).then(() => {
-            return PublishNextToAllNetworks(repository, network)().then(() => {
+            return PublishNextToAllNetworks(repository, network, errorTracker)().then(() => {
                 // TODO: test that publish was called with each post
                 expect(network.publish).toHaveBeenCalledTimes(2);
 

--- a/src/Bot/Posts/Application/Commands/PublishNextToAllNetworks/index.ts
+++ b/src/Bot/Posts/Application/Commands/PublishNextToAllNetworks/index.ts
@@ -2,8 +2,14 @@ import PostsRepository from '../../../Domain/PostsRepository';
 import { Post } from '../../../Domain/Post';
 import { SocialNetwork } from '../../../Domain/SocialNetwork';
 import { PostId } from '../../../Domain/PostId';
+import ErrorTracker from '../../../../../App/Services/ErrorTracker/Domain/ErrorTracker';
 
-const PublishNextToAllNetworks = (postsRepository: PostsRepository, socialNetworks: SocialNetwork) => {
+
+const PublishNextToAllNetworks = (
+    postsRepository: PostsRepository, 
+    socialNetworks: SocialNetwork,
+    errorTracker: ErrorTracker
+) => {
     return async () => {
         const nextPost = await postsRepository.getNextPost();
         if (!nextPost) {
@@ -12,6 +18,11 @@ const PublishNextToAllNetworks = (postsRepository: PostsRepository, socialNetwor
         }
 
         const posts = await postsRepository.getPostsByCrossPostId(nextPost.getCrossPostId());
+
+        errorTracker.setContext('nextPosts', {
+            nextPostId: nextPost.getId().getValue(),
+            posts: JSON.stringify(posts.map((post) => post.toObject())),
+        });
 
         return Promise.all(posts.map((post: Post) => {
             return socialNetworks.publish(post).then(() => {

--- a/src/Bot/Posts/Framework/PostsServiceProvider/index.ts
+++ b/src/Bot/Posts/Framework/PostsServiceProvider/index.ts
@@ -32,7 +32,11 @@ const PostsServiceProvider = () => {
 
 const registerCommands = (): void => {
     bind('PublishNextToAllNetworks', () => {
-        return PublishNextToAllNetworks(resolve('PostsRepository'), resolve('socialNetworks'));
+        return PublishNextToAllNetworks(
+            resolve('PostsRepository'), 
+            resolve('socialNetworks'), 
+            resolve('ErrorTracker')
+        );
     })
 }
 

--- a/src/Bot/Posts/Infrastructure/MockSocialNetwork/index.ts
+++ b/src/Bot/Posts/Infrastructure/MockSocialNetwork/index.ts
@@ -4,7 +4,7 @@ import { Post } from '../../Domain/Post';
 export default (): SocialNetwork => {
     return {
         publish: (post: Post) => {
-            console.log(`Published post: ${post.getId()}`);
+            console.log(`Published post: ${post.getId().getValue()}`);
             return Promise.resolve();
         },
     }


### PR DESCRIPTION
## About
This adds more context to Sentry error tracking by including all of the posts that are in scope to be posted so it's known which posts caused the error or may need manual intervention to clean them up. 

This also adds a new deploy workflow step to tell Sentry of a new release which helps identify which commits broke production.

## Secrets
For the Sentry release workflow step new secrets were added to the repo:
- `SENTRY_AUTH_TOKEN`
- `SENTRY_ORG`
- `SENTRY_PROJECT`

## Related 
https://docs.sentry.io/product/releases/ 